### PR TITLE
Add disable_general_search configuration option to prevent searches

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -22,6 +22,7 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
+        schema['disable_general_search'] = config.Boolean(True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_youtube/ext.conf
+++ b/mopidy_youtube/ext.conf
@@ -1,4 +1,5 @@
 [youtube]
 enabled = true
+disable_general_search = false
 # TODO: Add additional config values and their default values here, or remove
 # this comment entirely.


### PR DESCRIPTION
Hi @dz0ny,

I had a bit of a play with this to see if I could do it. This is only the second time I've really tackled an issue in Python, so I apologise if anything doesn't appear to be written as you'd expect. I'm very open to any criticism, and if this is something that you're interested in (but needs more work) please let me know and I'll do my best to assist.

Thanks,
connrs.

Commit message:

As part of my investigation in to issue #8, I've added the configuration
option disable_general_search (Boolean) to the config schema. Now, when
search is called (and it isn't a uri based search), it checked whether
disable_general_search is set to true. If it is true, then it parses the
search parameters to see if there is a valid URL with youtube.com in it.
If it finds youtube.com, the search will recurse but this time, the uri
will be set in the query so that it performs a search on the URL passed
in.

This should mean that the extension only goes to Youtube if it's
definitely a URL for youtube.
