### PR TITLE
configurable search max_results and processes

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '2.0.2'
+__version__ = '2.0.2.1'
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,8 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
+        schema['max_results'] = config.Integer()
+        schema['processes'] = config.Integer()
         return schema
 
     def setup(self, registry):

--- a/mopidy_youtube/ext.conf
+++ b/mopidy_youtube/ext.conf
@@ -1,2 +1,4 @@
 [youtube]
 enabled = true
+processes = 16
+max_results = 15


### PR DESCRIPTION
As an attempt to help with #24 and #26, this PR makes search `max_results` and threaded `processes` configurable.

The default of 16 processes is too much for underpowered single-core devices (such as raspberry pi 1) as simply `import pafy` takes a long time (around 3s).
So the overhead of doing that for 16 processes with very little gain (of multiprocessing on a single core) results in lower performance than without any multiprocessing at all.

From my tests, with this configurable, setting `processes` to 2 or 3 for a RPi1 yelds the best results.

Made `max_results` configurable as well, in case someone prefer getting fewer results quicker than many slower..
