### PR TITLE
Fixed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: python
 
 python:
-  - "2.7_with_system_site_packages"
+  - "2.7"
 
 env:
   - TOX_ENV=py27

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -98,7 +98,7 @@ def test_lookup_video_uri(caplog):
                             '/a title.C0DPdy98e4c')
 
     assert 'Need 11 character video id or the URL of the video.' \
-           not in caplog.text()
+           not in caplog.text
 
     assert track
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     mock
     pytest
     pytest-cov
-    pytest-capturelog
     pytest-xdist
     vcrpy
 commands =
@@ -17,6 +16,8 @@ commands =
         --junit-xml=xunit-{envname}.xml \
         --cov=mopidy_youtube --cov-report=term-missing \
         {posargs}
+setenv =
+    PAFY_BACKEND = internal
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Added enviromental variable PAFY_BACKEND = internal which fix problem with youtube-dl depencency, removed redundant pytest-capturelog since is included in core, changed version of python, changed caplog.text() to caplog.text according to documentation https://docs.pytest.org/en/latest/logging.html