### PR TITLE
Added youtube_dl to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 install:
   - "pip install tox"
+  - "pip install youtube_dl"
 
 script:
   - "tox -e $TOX_ENV"


### PR DESCRIPTION
Added youtube_dl to .travis.yml because this package is using it.

```
"pafy: youtube-dl not found; you can use the internal backend by "
E   ImportError: pafy: youtube-dl not found; you can use the internal backend by setting the environmental variable PAFY_BACKEND to "internal". It is not enabled by default because it is not as well maintained as the youtube-dl backend.
```
