### PR TITLE
Added youtube_dl since this is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 install:
   - "pip install tox"
+  - "pip install youtube_dl"
 
 script:
   - "tox -e $TOX_ENV"


### PR DESCRIPTION
Added youtube_dl to .travis.yml because this branch `develop` is used in:
https://github.com/mopidy/mopidy-youtube/pull/104