### PR TITLE
Add YouTube Music search provider

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -28,6 +28,7 @@ class Extension(ext.Extension):
         schema['search_results'] = config.Integer(minimum=1)
         schema['playlist_max_videos'] = config.Integer(minimum=1)
         schema['api_enabled'] = config.Boolean()
+        schema['music_enabled'] = config.Boolean()
         return schema
 
     def setup(self, registry):

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -57,6 +57,7 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
         youtube.Playlist.playlist_max_videos = \
             config['youtube']['playlist_max_videos']
         youtube.api_enabled = config['youtube']['api_enabled']
+        youtube.music_enabled = config['youtube']['music_enabled']
         self.uri_schemes = ['youtube', 'yt']
         self.user_agent = '%s/%s' % (
             Extension.dist_name,
@@ -89,6 +90,11 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
         if youtube.api_enabled is False:
             logger.info('Using scrAPI')
             youtube.Entry.api = youtube.scrAPI(proxy, headers)
+
+        if youtube.music_enabled is True:
+            logger.info('Using YouTube Music API')
+            music = youtube.Music(proxy, headers)
+            youtube.Entry.api.search = music.search
 
         # logger.info('using jAPI')
         # youtube.Entry.api = youtube.jAPI()

--- a/mopidy_youtube/ext.conf
+++ b/mopidy_youtube/ext.conf
@@ -5,4 +5,4 @@ threads_max = 16
 search_results = 15
 playlist_max_videos = 20
 api_enabled = false
-
+music_enabled = false

--- a/mopidy_youtube/youtube.py
+++ b/mopidy_youtube/youtube.py
@@ -147,7 +147,7 @@ class Entry(object):
             elif k == 'title':
                 val = item['snippet']['title']
             elif k == 'channel':
-                val = item['snippet']['channelTitle']
+                val = item['snippet']['channelTitle'] if 'channelTitle' in item['snippet'] else item['snippet']['title']
             elif k == 'length':
                 # convert PT1H2M10S to 3730
                 m = re.search(r'P((?P<weeks>\d+)W)?'
@@ -840,3 +840,141 @@ class ThreadPool:
             cls.threads_active += 1
 
         cls.lock.release()
+
+
+# Direct access to YouTube Music API
+#
+class Music(Client):
+    endpoint = 'https://music.youtube.com'
+    searchEndpoint = endpoint + '/youtubei/v1/search'
+    api_key = ''
+
+    # Get YouTube Music Token
+    #
+    @classmethod
+    def get_token(cls):
+        if not Music.api_key:
+            headers = {
+                'user-agent':
+                'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:66.0)'
+                ' Gecko/20100101 Firefox/66.0',
+                'Cookie': 'PREF=hl=en;',
+                'Accept-Language': 'en;q=0.5',
+                'content_type': 'application/json'
+            }
+
+            response = cls.session.get(Music.endpoint, headers=headers)
+
+            json_regex = r'ytcfg.set\((.*?)\);'
+            extracted_json = re.search(json_regex, response.text).group(1)
+
+            Music.api_key = json.loads(extracted_json)['INNERTUBE_API_KEY']
+        return Music.api_key
+
+    @classmethod
+    def base_search(cls, q, videos=True):
+        searchHeaders = {
+            'Referer': 'https://music.youtube.com/',
+            'Content-Type': 'application/json',
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:71.0) Gecko/20100101 Firefox/71.0',
+            'Accept': '*/*',
+            'Accept-Language': 'en-US,en;q=0.5',
+        }
+
+        query = {
+            'alt': 'json',
+            'key': cls.get_token(),
+        }
+
+        typeFilter = {
+            'songs': 'Eg-KAQwIARAAGAAgACgAMABqChAJEAMQBBAKEAU%3D',
+            'albums': 'Eg-KAQwIABAAGAEgACgAMABqChAJEAMQBBAKEAU%3D'
+        }
+
+        data = {
+            "context": {
+                "client": {
+                    "clientName": "WEB_REMIX",
+                    "clientVersion": "0.1",
+                    "hl": "en",
+                    "gl": "US",
+                },
+            },
+            "query": "blind guardian",
+            "params": typeFilter['songs'] if videos else typeFilter['albums']
+        }
+
+        json_response = cls.session.post(
+            Music.searchEndpoint, params=query, headers=searchHeaders, json=data)
+
+        result_json = json_response.json()['contents']['sectionListRenderer']['contents']
+
+        items = []
+        for content in result_json:
+            items.append(content['musicShelfRenderer']['contents'])
+
+
+        normalized_items = []
+        for thing in items:
+            for x in thing:
+                normalized_items.append(x['musicResponsiveListItemRenderer'])
+
+        return normalized_items
+
+    @classmethod
+    def search_videos(cls, q):
+        results = cls.base_search(q)
+        videos = []
+        for item in results:
+            video = {}
+            video.update({
+                'id': {
+                    'kind': 'youtube#video',
+                    'videoId': item['doubleTapCommand']['watchEndpoint']['videoId']
+                },
+                # 'contentDetails': {
+                #     'duration': 'PT'+duration
+                # }
+                'snippet': {
+                    'title': item['flexColumns'][1]['musicResponsiveListItemFlexColumnRenderer']['text']['runs'][0]['text'],  # noqa: E501
+                    'thumbnails': {
+                        'default': item['thumbnail']['musicThumbnailRenderer']['thumbnail']['thumbnails'][0],
+                    },
+                    'channelTitle': item['flexColumns'][0]['musicResponsiveListItemFlexColumnRenderer']['text']['runs'][0]['text'],  # noqa: E501
+                },
+            })
+            videos.append(video)
+        return videos
+
+    @classmethod
+    def search_albums(cls, q):
+        results = cls.base_search(q, videos=False)
+
+        playlists = []
+        for item in results:
+            playlist = {}
+            playlist.update({
+                'id': {
+                    'kind': 'youtube#playlist',
+                    'playlistId': item['doubleTapCommand']['watchPlaylistEndpoint']['playlistId']
+                },
+                'snippet': {
+                    'channelTitle': item['flexColumns'][1]['musicResponsiveListItemFlexColumnRenderer']['text']['runs'][0]['text'],  # noqa: E501
+                    'thumbnails': {
+                        'default': item['thumbnail']['musicThumbnailRenderer']['thumbnail']['thumbnails'][0],
+                    },
+                    'title': item['flexColumns'][0]['musicResponsiveListItemFlexColumnRenderer']['text']['runs'][0]['text'],  # noqa: E501
+                },
+            })
+            playlists.append(playlist)
+        return playlists
+
+
+    @classmethod
+    def search(cls, q):
+        items =  cls.search_albums(q) + cls.search_videos(q)
+        return json.loads(json.dumps(
+            {'items': [i for i in items if i]},
+            sort_keys=False,
+            indent=1
+        ))


### PR DESCRIPTION
Not sure if this is desired, but I added a sort of rudimentary YouTube Music based search provider. I took a lot of inspiration from the jAPI implementation, which is similar but not music specific

I still need to:

* Implement pagination (we only get first page results as of right now)
* Reduce some hard coded values and/or make them configurable (not everyone is in the US)
* Call out how utterly experimental this is and how likely it is that YouTube Music breaks this implementation
* Implement any feedback given
* Remove constraint to search only by "Any", since the YouTube Music API allows us to search by Artist, Album or Song
* Add tests and fix failing tests

If this isn't wanted, feel free to tell me and I'll just maintain this little class for my own fork or spin this off into `mopidy-youtube-music` :)