### PR TITLE
Fix documentation for `api_enabled` flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ and set api_enabled = true::
 
     [youtube]
     youtube_api_key = <api key you got from Google>
-    api_enabled = false
+    api_enabled = true
 
 Other configuration options are::
 


### PR DESCRIPTION
Your example isn't lining up with the text above it. Looks like a mistake 