### PR TITLE
Added Youtube Music "my playlist"

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -25,6 +25,7 @@ class Extension(ext.Extension):
         schema["playlist_max_videos"] = config.Integer(minimum=1)
         schema["api_enabled"] = config.Boolean(optional=True)
         schema["musicapi_enabled"] = config.Boolean(optional=True)
+        schema["musicapi_cookie"] = config.String(optional=True)
         schema["autoplay_enabled"] = config.Boolean(optional=True)
         schema["strict_autoplay"] = config.Boolean(optional=True)
         schema["max_autoplay_length"] = config.Integer()

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pykka
 from mopidy import backend, httpclient
-from mopidy.models import Album, Artist, SearchResult, Track
+from mopidy.models import Album, Artist, SearchResult, Track, Ref
 
 from mopidy_youtube import Extension, logger, youtube
 from mopidy_youtube.apis import youtube_api, youtube_bs4api, youtube_music
@@ -98,6 +98,7 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
         ]
         youtube.api_enabled = config["youtube"]["api_enabled"]
         youtube.musicapi_enabled = config["youtube"]["musicapi_enabled"]
+        youtube.musicapi_cookie = config["youtube"].get("musicapi_cookie", None)
         self.uri_schemes = ["youtube", "yt"]
         self.user_agent = "{}/{}".format(Extension.dist_name, Extension.version)
 
@@ -130,8 +131,19 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
 
         if youtube.musicapi_enabled is True:
             logger.info("Using YouTube Music API")
+            if youtube.musicapi_cookie:
+                headers.update(
+                    {
+                        "Accept": "*/*",
+                        "Accept-Language": "en-US,en;q=0.5",
+                        "Content-Type": "application/json",
+                        "origin": "https://music.youtube.com",
+                        "Cookie": youtube.musicapi_cookie,
+                    }
+                )
             music = youtube_music.Music(proxy, headers)
             youtube.Entry.api.search = music.search
+            youtube.Entry.api.browse = music.browse
             youtube.Entry.api.list_playlistitems = music.list_playlistitems
             if youtube.api_enabled is False:
                 youtube.Entry.api.list_playlists = music.list_playlists
@@ -155,6 +167,32 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
     YouTubeLibraryProvider.lookup) will most likely be instantaneous, since
     all info will be ready by that time.
     """
+
+    root_directory = Ref.directory(
+        uri="youtube:channel", name="My Youtube playlists"
+    )
+
+    def browse(self, uri):
+        if uri.startswith("youtube:playlist"):
+            logger.info("browse playlist: " + uri)
+            trackrefs = []
+            tracks = self.lookup(uri)
+            for track in tracks:
+                trackrefs.append(Ref.track(uri=track.uri, name=track.name))
+            return trackrefs
+        elif uri.startswith("youtube:channel"):
+            logger.info("browse channel: " + uri)
+            playlistrefs = []
+            albums = []
+            playlists = youtube.Entry.api.browse()
+            playlists = list(map(youtube.Entry.create_object, playlists))
+            for pl in playlists:
+                albums.append(convert_playlist_to_album(pl))
+            for album in albums:
+                playlistrefs.append(
+                    Ref.playlist(uri=album.uri, name=album.name)
+                )
+            return playlistrefs
 
     def search(self, query=None, uris=None, exact=False):
         # TODO Support exact search

--- a/mopidy_youtube/ext.conf
+++ b/mopidy_youtube/ext.conf
@@ -5,6 +5,7 @@ search_results = 15
 playlist_max_videos = 20
 api_enabled = false
 musicapi_enabled = false
+musicapi_cookie = 
 autoplay_enabled = false
 strict_autoplay = false
 max_autoplay_length = 600

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     requests
     setuptools
     youtube_dl >= 2020.12.22
-    ytmusicapi
+    ytmusicapi >= 0.17
 
 [options.extras_require]
 lint =


### PR DESCRIPTION
This PR adds the capability to see "my playlists" from youtube music into mopidy clients.
This fixes #161 

Usage: Since youtube-music currently does not support api, this requires you to set your browser cookie into mopidy
youtube config (`musicapi_cookie`).  You can obtain the cookie by process mentioned in the [ytmusicapi readme](https://ytmusicapi.readthedocs.io/en/latest/setup.html#copy-authentication-headers). 
You only have to look out for `Cookie` in the network tab instead of all the headers. Set it into modify.conf. For example, my config looks something like this:

```
[youtube]
enabled = true
youtube_api_key = xxxxxxxxxxxxxxx
musicapi_cookie = YSC=GcdzWXaAXlA; VISITOR_INFO1_LIVE=wDfGmn5eIUI; LOGIN_INFO=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; HSID=yyyyyyyyyyyyyyy; SSID=pppppppppp; APISID=qqqqqqqqqqq; SAPISID=rrrrrrrrrrrrrrrr; __Secure-3PAPISID=sssssssssssssssssss; wide=0; SID=-ttttttttttttttttttt.; __Secure-3PSID=-uuuuuuuuuuuuuuuuuuuuuu.; ... <... rest of cookie>
search_results = 15
playlist_max_videos = 20
api_enabled = false
musicapi_enabled = true
autoplay_enabled = true
strict_autoplay = false
max_autoplay_length = 600
max_degrees_of_separation = 3
```

Then restart mopidy service and you should be able to see the "My Youtube playlist" in the "Browse" section.

![image](https://user-images.githubusercontent.com/1492350/123327639-46682200-d558-11eb-828a-48b927029136.png)
---
NOTE: Currently only youtube-music is supported. Support for YouTube video is aleady added in PR #174

TODO:
- Write tests
- Add documentation
- Merge with PR #174 