### PR TITLE
Gmusic playlists

### DIFF
--- a/mopidy_youtube/__init__.py
+++ b/mopidy_youtube/__init__.py
@@ -25,6 +25,7 @@ class Extension(ext.Extension):
         schema["playlist_max_videos"] = config.Integer(minimum=1)
         schema["api_enabled"] = config.Boolean(optional=True)
         schema["musicapi_enabled"] = config.Boolean(optional=True)
+        schema["musicapi_cookie"] = config.String(optional=True)
         schema["autoplay_enabled"] = config.Boolean(optional=True)
         schema["strict_autoplay"] = config.Boolean(optional=True)
         schema["max_autoplay_length"] = config.Integer()

--- a/mopidy_youtube/apis/youtube_music.py
+++ b/mopidy_youtube/apis/youtube_music.py
@@ -17,7 +17,13 @@ class Music(Client):
     def __init__(self, proxy, headers, *args, **kwargs):
         global ytmusic
         super().__init__(proxy, headers, *args, **kwargs)
-        ytmusic = YTMusic(auth=json.dumps(headers))
+        auth = None if headers.get('Cookie', None) is None else \
+            json.dumps(headers)
+        try:
+            ytmusic = YTMusic(auth=auth)
+        except Exception as e:
+            logger.error("YTMusic init error: %s", str(e))
+            ytmusic = YTMusic()
 
     @classmethod
     def search(cls, q):

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -131,16 +131,15 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
 
         if youtube.musicapi_enabled is True:
             logger.info("Using YouTube Music API")
-            if youtube.musicapi_cookie:
-                headers.update(
-                    {
-                        "Accept": "*/*",
-                        "Accept-Language": "en-US,en;q=0.5",
-                        "Content-Type": "application/json",
-                        "origin": "https://music.youtube.com",
-                        "Cookie": youtube.musicapi_cookie,
-                    }
-                )
+            headers.update(
+                {
+                    "Accept": "*/*",
+                    "Accept-Language": "en-US,en;q=0.5",
+                    "Content-Type": "application/json",
+                    "origin": "https://music.youtube.com",
+                    "Cookie": youtube.musicapi_cookie or None,
+                }
+            )
             music = youtube_music.Music(proxy, headers)
             youtube.Entry.api.search = music.search
             youtube.Entry.api.browse = music.browse

--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pykka
 from mopidy import backend, httpclient
-from mopidy.models import Album, Artist, SearchResult, Track
+from mopidy.models import Album, Artist, SearchResult, Track, Ref
 
 from mopidy_youtube import Extension, logger, youtube
 from mopidy_youtube.apis import youtube_api, youtube_bs4api, youtube_music
@@ -98,6 +98,7 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
         ]
         youtube.api_enabled = config["youtube"]["api_enabled"]
         youtube.musicapi_enabled = config["youtube"]["musicapi_enabled"]
+        youtube.musicapi_cookie = config["youtube"].get("musicapi_cookie", None)
         self.uri_schemes = ["youtube", "yt"]
         self.user_agent = "{}/{}".format(Extension.dist_name, Extension.version)
 
@@ -130,8 +131,19 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
 
         if youtube.musicapi_enabled is True:
             logger.info("Using YouTube Music API")
+            if youtube.musicapi_cookie:
+                headers.update(
+                    {
+                        "Accept": "*/*",
+                        "Accept-Language": "en-US,en;q=0.5",
+                        "Content-Type": "application/json",
+                        "origin": "https://music.youtube.com",
+                        "Cookie": youtube.musicapi_cookie,
+                    }
+                )
             music = youtube_music.Music(proxy, headers)
             youtube.Entry.api.search = music.search
+            youtube.Entry.api.browse = music.browse
             youtube.Entry.api.list_playlistitems = music.list_playlistitems
             if youtube.api_enabled is False:
                 youtube.Entry.api.list_playlists = music.list_playlists
@@ -155,6 +167,32 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
     YouTubeLibraryProvider.lookup) will most likely be instantaneous, since
     all info will be ready by that time.
     """
+
+    root_directory = Ref.directory(
+        uri="youtube:channel", name="My Youtube playlists"
+    )
+
+    def browse(self, uri):
+        if uri.startswith("youtube:playlist"):
+            logger.info("browse playlist: " + uri)
+            trackrefs = []
+            tracks = self.lookup(uri)
+            for track in tracks:
+                trackrefs.append(Ref.track(uri=track.uri, name=track.name))
+            return trackrefs
+        elif uri.startswith("youtube:channel"):
+            logger.info("browse channel: " + uri)
+            playlistrefs = []
+            albums = []
+            playlists = youtube.Entry.api.browse()
+            playlists = list(map(youtube.Entry.create_object, playlists))
+            for pl in playlists:
+                albums.append(convert_playlist_to_album(pl))
+            for album in albums:
+                playlistrefs.append(
+                    Ref.playlist(uri=album.uri, name=album.name)
+                )
+            return playlistrefs
 
     def search(self, query=None, uris=None, exact=False):
         # TODO Support exact search

--- a/mopidy_youtube/ext.conf
+++ b/mopidy_youtube/ext.conf
@@ -5,6 +5,7 @@ search_results = 15
 playlist_max_videos = 20
 api_enabled = false
 musicapi_enabled = false
+musicapi_cookie = 
 autoplay_enabled = false
 strict_autoplay = false
 max_autoplay_length = 600

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     requests
     setuptools
     youtube_dl >= 2020.12.22
-    ytmusicapi
+    ytmusicapi >= 0.17
 
 [options.extras_require]
 lint =


### PR DESCRIPTION
Fixes #184 

TODO:

- [x] ytmusic without auth seems broken
- [ ] ytmusic albums vs ytmusic playlists; might have to turn albums into playlists and then pass both as mopidy playlists
- [ ] remove duplicated browse method in backend.py introduced after the merge
- [ ] Write unit tests