### PR TITLE
Fix: Pick ytmusic authenticated channel if channel_id is not configured

### DIFF
--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -160,6 +160,11 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
         uri="youtube:channel", name="My Youtube playlists"
     )
 
+    def is_channel_configured(self):
+        ytapi_channel = youtube.channel in ("", None)
+        ytmusic_channel = youtube.musicapi_enabled and youtube.musicapi_cookie
+        return (not ytapi_channel) or ytmusic_channel
+
     """
     Called when root_directory is set to the URI of the youtube channel ID in the mopidy.conf
     When enabled makes possible to browse public playlists of the channel as well as browse separate tracks in playlists
@@ -176,7 +181,7 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
             return trackrefs
         elif uri.startswith("youtube:channel"):
             logger.info("browse channel / library")
-            if youtube.channel in ("", None):
+            if not self.is_channel_configured():
                 logger.info(
                     "no channel / library to browse, please set up one in the config"
                 )


### PR DESCRIPTION
This is a small patch related to the [idea of auto-picking authenticated channel](https://github.com/natumbri/mopidy-youtube/commit/91d8eb5d4c53ad1429943ae26cbf931043d8209c#r52955713) if one is not already configured.

It is better than a blank playlist, since most probably, user with single channel will likely want to see his own playlists as a default action.

/cc @natumbri 