### PR TITLE
Add Authorization header as required by ytmusicapi

### DIFF
--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -160,6 +160,7 @@ class YouTubeBackend(pykka.ThreadingActor, backend.Backend):
                     "Content-Type": "application/json",
                     "origin": "https://music.youtube.com",
                     "x-origin": "https://music.youtube.com",  # seems to be needed?
+                    "Authorization": "",  # needed by ytmusicapi
                 }
             )
 


### PR DESCRIPTION
Fixes the error:

```
YTMusic init error:  Could not detect credential type. Please ensure your oauth or browser credentials are set up correctly.
```

caused by [ytmusicapi now requiring the authorization header](https://github.com/sigma67/ytmusicapi/commit/e457402633a9df38a07cf734603b4ae1fbc466d2#diff-a0c7f64bfe20cb4177f7ef7f1bebae9280213b142263bba62f6659b9d57e56b3R12).