### PR TITLE
fix(core): Migrate to Mopidy v4.0 API

### DIFF
--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -5,7 +5,15 @@ import pykka
 from cachetools import TTLCache, cached
 from mopidy import backend, httpclient, listener
 from mopidy.core import CoreListener
-from mopidy.models import Image, Ref, SearchResult, Track, model_json_decoder
+
+from mopidy.models import Image, Ref, SearchResult, Track
+
+try:
+    # Mopidy < 4.0
+    from mopidy.models import model_json_decoder
+except ImportError:
+    # Mopidy >= 4.0
+    model_json_decoder = None
 
 from mopidy_youtube import Extension, logger, youtube
 from mopidy_youtube.apis import youtube_japi
@@ -415,7 +423,12 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
                 with open(
                     os.path.join(youtube.cache_location, f"{video_id}.json"), "r"
                 ) as infile:
-                    track = json.load(infile, object_hook=model_json_decoder)
+                    if model_json_decoder:
+                        # Mopidy < 4.0
+                        track = json.load(infile, object_hook=model_json_decoder)
+                    else:
+                        # Mopidy >= 4.0
+                        track = Track.model_validate(json.load(infile))
                 return track
 
         video = youtube.Video.get(video_id)

--- a/mopidy_youtube/frontend.py
+++ b/mopidy_youtube/frontend.py
@@ -1,7 +1,7 @@
 import random
 
 import pykka
-from mopidy.core import listener
+from mopidy.core import CoreListener
 
 from mopidy_youtube import logger, youtube
 from mopidy_youtube.data import extract_video_id, format_video_uri
@@ -13,7 +13,7 @@ max_autoplay_length = None
 max_degrees_of_separation = 3
 
 
-class YouTubeAutoplayer(pykka.ThreadingActor, listener.CoreListener):
+class YouTubeAutoplayer(pykka.ThreadingActor, CoreListener):
     def __init__(self, config, core):
         super().__init__()
         self.config = config

--- a/mopidy_youtube/youtube.py
+++ b/mopidy_youtube/youtube.py
@@ -5,7 +5,15 @@ from concurrent.futures.thread import ThreadPoolExecutor
 
 import pykka
 from cachetools import TTLCache, cached
-from mopidy.models import Image, ModelJSONEncoder
+
+from mopidy.models import Image
+
+try:
+    # Mopidy < 4.0
+    from mopidy.models import ModelJSONEncoder
+except ImportError:
+    # Mopidy >= 4.0
+    ModelJSONEncoder = None
 
 from mopidy_youtube import logger
 from mopidy_youtube.converters import convert_video_to_track
@@ -558,16 +566,28 @@ class Video(Entry):
                     # missing, even if the audio and the image do not
                     if f"{self.id}.json" not in os.listdir(cache_location):
                         logger.debug(f"caching metadata {self.id}")
+                        track = convert_video_to_track(
+                            self, bitrate=int(info.get("tbr", 0))
+                        )
+
                         with open(
                             os.path.join(cache_location, f"{self.id}.json"), "w"
                         ) as outfile:
-                            json.dump(
-                                convert_video_to_track(
-                                    self, bitrate=int(info.get("tbr", 0))
-                                ),
-                                cls=ModelJSONEncoder,
-                                fp=outfile,
-                            )
+                            if ModelJSONEncoder:
+                                # Mopidy < 4.0
+                                json.dump(
+                                    track,
+                                    cls=ModelJSONEncoder,
+                                    fp=outfile,
+                                )
+                            else:
+                                # Mopidy >= 4.0
+                                json.dump(
+                                    track.model_dump_json(
+                                        by_aliases=True, exclude_none=True
+                                    ),
+                                    fp=outfile,
+                                )
                 else:
                     with youtube_dl.YoutubeDL(ytdl_options) as ydl:
                         info = ydl.extract_info(


### PR DESCRIPTION
This fix also maintains back-compatibility with Mopidy versions <4.0 - it will try to import the old names and fall back to the new Pydantic models if they are not available.

Closes: #255