### PR TITLE
fix: prevent cache write failures with Pydantic v2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 *********
 
+Unreleased
+========================================
+
+- fix Pydantic v2 model serialization keyword in cache metadata (use by_alias)
+
 v3.7 (2023-05-15)
 ========================================
 

--- a/mopidy_youtube/youtube.py
+++ b/mopidy_youtube/youtube.py
@@ -601,7 +601,8 @@ class Video(Entry):
                                 # Mopidy >= 4.0
                                 json.dump(
                                     track.model_dump_json(
-                                        by_aliases=True, exclude_none=True
+                                        by_alias=True,
+                                        exclude_none=True,
                                     ),
                                     fp=outfile,
                                 )

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -83,6 +83,22 @@ def test_audio_url(api, config, headers, youtube_dl_mock_with_video):
 
 
 @pytest.mark.parametrize("api", apis)
+def test_audio_url_with_cache_metadata(api, config, headers, youtube_dl_mock_with_video, tmp_path):
+    setup_entry_api(api, config, headers)
+    youtube.Video.proxy = None
+    youtube.cache_location = str(tmp_path)
+    video = youtube.Video.get("e1YqueG2gtQ")
+
+    (tmp_path / f"{video.id}.webm").write_bytes(b"cached audio")
+    (tmp_path / f"{video.id}.webp").write_bytes(b"cached image")
+
+    assert video.audio_url.get()
+    assert (tmp_path / f"{video.id}.json").exists()
+
+    youtube.cache_location = None
+
+
+@pytest.mark.parametrize("api", apis)
 def test_audio_url_fail(api, config, headers, youtube_dl_mock):
     setup_entry_api(api, config, headers)
     youtube.Video.proxy = None


### PR DESCRIPTION
## Description

This addresses the runtime error: `BaseModel.model_dump_json() got an unexpected keyword argument 'by_aliases'`

- Changed `by_aliases=True` to `by_alias=True` in `mopidy_youtube/youtube.py` when calling `track.model_dump_json()`.
- Added a new test `test_audio_url_with_cache_metadata` in `tests/test_youtube.py` to cover cache metadata writes.
- Added a note to `CHANGELOG.rst` for the unreleased fix.

## Context

Mopidy 4.0 migrates its models to Pydantic v2, which removed the `by_aliases` keyword argument in favor of `by_alias`. When caching is enabled (`allow_cache = true`), `mopidy-youtube` writes cached metadata via `model_dump_json()`, and this raises a `TypeError` in Pydantic v2 that prevents playback. This change updates the keyword to restore compatibility and avoid cache-related runtime failures.

## How Has This Been Tested?

Environment: local container with Python 3.13.13, Mopidy 4.0.0, and Pydantic 2.13.3.

<details>
<summary>Dockerfile</summary>

```Dockerfile
FROM python:3.13-slim

ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update \
    && apt-get install -y --no-install-recommends \
        build-essential \
        pkg-config \
        git \
        curl \
        libcairo2-dev \
        libgirepository1.0-dev \
        libgirepository-2.0-dev \
        gobject-introspection \
        libglib2.0-dev \
        python3-gi \
        python3-gi-cairo \
        python3-gst-1.0 \
        gstreamer1.0 \
        gstreamer1.0-plugins-base \
        gstreamer1.0-plugins-bad \
        gstreamer1.0-plugins-good \
        gstreamer1.0-plugins-ugly \
        gstreamer1.0-tools \
        gstreamer1.0-libav \
        gir1.2-gstreamer-1.0 \
    && rm -rf /var/lib/apt/lists/* \
    && python -m pip install --upgrade pip \
    && python -m pip install "setuptools<71"
```

</details>

<details>
<summary>Dependency versions</summary>

```text
Python 3.13.13
pip 26.1
setuptools 70.3.0
build-essential 12.12
pkg-config 1.8.1-4
git 1:2.47.3-0+deb13u1
curl 8.14.1-2+deb13u2
libcairo2-dev 1.18.4-1+b1
libgirepository1.0-dev 1.84.0-1
libgirepository-2.0-dev 2.84.4-3~deb13u2
gobject-introspection 1.84.0-1
libglib2.0-dev 2.84.4-3~deb13u2
python3-gi 3.50.0-4+b1
python3-gi-cairo 3.50.0-4+b1
python3-gst-1.0 1.26.2-1
gstreamer1.0 meta package (not installed directly)
gstreamer1.0-plugins-base 1.26.2-1+deb13u1
gstreamer1.0-plugins-bad 1.26.2-3+deb13u1
gstreamer1.0-plugins-good 1.26.2-1
gstreamer1.0-plugins-ugly 1.26.3-4+deb13u1
gstreamer1.0-tools 1.26.2-2
gstreamer1.0-libav 1.26.2-1
gir1.2-gstreamer-1.0 1.26.2-2
```

</details>

Tests run:

- `pytest tests/test_youtube.py -k test_audio_url_with_cache_metadata`
- `pytest`
