### PR TITLE
Fix jAPI playlists intermittently returning empty (shell playlist page)

### DIFF
--- a/mopidy_youtube/apis/youtube_japi.py
+++ b/mopidy_youtube/apis/youtube_japi.py
@@ -335,19 +335,37 @@ class jAPI(Client):
 
         return json.loads(json.dumps({"items": items}, sort_keys=False, indent=1))
 
+    # YouTube intermittently serves a video-less "shell" of the playlist page
+    # (a sectionListRenderer without playlistVideoListRenderer) that can't be
+    # parsed inline. A re-fetch almost always returns the full page, so retry a
+    # few times before giving up rather than letting a single bad response
+    # silently yield an empty playlist.
+    playlistitem_retries = 3
+
     @classmethod
     def list_playlistitems(cls, id, page, max_results):
         query = {"list": id, "app": "desktop", "persist_app": 1}
         logger.debug(f"jAPI 'list_playlistitems' triggered session.get: {id}")
 
-        items = []
-
-        result = cls.session.get(urljoin(cls.endpoint, "playlist"), params=query)
-        if result.status_code == 200:
+        for attempt in range(cls.playlistitem_retries):
+            result = cls.session.get(
+                urljoin(cls.endpoint, "playlist"), params=query
+            )
+            if result.status_code != 200:
+                break
             yt_data = cls._find_yt_data(result.text)
-            extracted_json = traverse(yt_data, listPlaylistItemsPath)
-            items = cls.json_to_items(extracted_json)
-            items = items[:max_results]
+            try:
+                extracted_json = traverse(yt_data, listPlaylistItemsPath)
+            except KeyError:
+                logger.debug(
+                    "jAPI 'list_playlistitems' got an incomplete playlist page "
+                    "for %s (attempt %d/%d); retrying",
+                    id,
+                    attempt + 1,
+                    cls.playlistitem_retries,
+                )
+                continue
+            items = cls.json_to_items(extracted_json)[:max_results]
             return json.loads(
                 json.dumps(
                     {"nextPageToken": None, "items": items},
@@ -356,7 +374,13 @@ class jAPI(Client):
                 )
             )
 
-        return []
+        logger.warning(
+            "jAPI 'list_playlistitems' could not retrieve playlist items for "
+            "%s after %d attempt(s)",
+            id,
+            cls.playlistitem_retries,
+        )
+        return {"nextPageToken": None, "items": []}
 
     @classmethod
     def list_channelplaylists(cls, channel_id):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,6 +93,67 @@ def test_api_list_playlistitems(api, config, headers):
         assert len(playlistitems["items"]) == 20
 
 
+def test_japi_list_playlistitems_retries_incomplete_page(config, headers, monkeypatch):
+    # YouTube intermittently serves a video-less "shell" playlist page that
+    # raises KeyError while parsing; list_playlistitems should re-fetch instead
+    # of letting a single bad response yield an empty playlist.
+    from mopidy_youtube.apis import youtube_japi
+
+    api = youtube_japi.jAPI(proxy=config["proxy"], headers=headers)
+
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, tag):
+            self.text = tag
+
+    responses = iter([_Resp("shell"), _Resp("complete")])
+    monkeypatch.setattr(api.session, "get", lambda *a, **k: next(responses))
+    monkeypatch.setattr(
+        youtube_japi.jAPI, "_find_yt_data", staticmethod(lambda text: {"page": text})
+    )
+
+    def fake_traverse(data, path):
+        if data["page"] == "shell":
+            raise KeyError  # incomplete shell page — no playlistVideoListRenderer
+        return ["v1", "v2"]
+
+    monkeypatch.setattr(youtube_japi, "traverse", fake_traverse)
+    monkeypatch.setattr(
+        youtube_japi.jAPI, "json_to_items", staticmethod(lambda extracted: list(extracted))
+    )
+
+    result = youtube_japi.jAPI.list_playlistitems("PLfake", None, 20)
+
+    assert result["items"] == ["v1", "v2"]  # retried past the shell page
+
+
+def test_japi_list_playlistitems_gives_up_cleanly(config, headers, monkeypatch):
+    # If every attempt is an unparseable shell page, return an empty-but-valid
+    # result rather than raising or returning a bare list.
+    from mopidy_youtube.apis import youtube_japi
+
+    api = youtube_japi.jAPI(proxy=config["proxy"], headers=headers)
+
+    class _Resp:
+        status_code = 200
+        text = "shell"
+
+    monkeypatch.setattr(api.session, "get", lambda *a, **k: _Resp())
+    monkeypatch.setattr(
+        youtube_japi.jAPI, "_find_yt_data", staticmethod(lambda text: {"page": text})
+    )
+
+    def always_fail(data, path):
+        raise KeyError
+
+    monkeypatch.setattr(youtube_japi, "traverse", always_fail)
+
+    result = youtube_japi.jAPI.list_playlistitems("PLfake", None, 20)
+
+    assert result == {"nextPageToken": None, "items": []}
+
+
 @pytest.mark.parametrize("api", apis)
 def test_api_list_channelplaylists(api, config, headers):
     with my_vcr.use_cassette(


### PR DESCRIPTION
### Problem

With the jAPI backend (`api_enabled = false`), browsing/looking up a YouTube **playlist** intermittently returns **zero tracks** — e.g. queuing a playlist URI via MPD `add` fails with `directory or file not found`, and Iris shows an empty playlist. Single videos are unaffected.

### Root cause

YouTube serves a video-less **"shell"** of the playlist page a meaningful fraction of the time (observed ~30% in testing): same top-level `twoColumnBrowseResultsRenderer`, but the tab content is a `sectionListRenderer` with **no `playlistVideoListRenderer`** (the real video list would load via a continuation request).

`jAPI.list_playlistitems()` parses the page with `traverse(yt_data, listPlaylistItemsPath)`, which raises a **bare `KeyError`** on that layout. `Playlist.videos()` catches it, logs an empty message (`str(KeyError()) == ""`, so the log line is literally `... error ""`) and `break`s the pagination loop — yielding a completely empty playlist. Because it's probabilistic per-request, the same playlist works on some loads and is empty on others, which made it hard to pin down.

This is **not** a bot block, cookie, User-Agent, or stale-JSON-path issue — the page returns HTTP 200 and the existing parser extracts the items correctly *when YouTube returns the full layout*.

### Fix

Retry the fetch a few times (`playlistitem_retries = 3`) before giving up, since a re-fetch almost always returns the full page. Also:

- Return a consistent dict shape (`{"nextPageToken": None, "items": []}`) on give-up instead of a bare `[]` — the bare list previously crashed the caller's `result.get(...)`.
- Replace the silent/empty-message failure with a `debug` log per retry and a `warning` if all attempts fail.

Empirically, with the retry the playlist loads succeeded 20/20 where individual fetches were failing ~30% of the time.

### Tests

Added two unit tests to `tests/test_api.py`:
- `test_japi_list_playlistitems_retries_incomplete_page` — a shell page followed by a complete page returns the items (retried).
- `test_japi_list_playlistitems_gives_up_cleanly` — all-shell returns an empty-but-valid result without raising.

The existing `test_api_list_playlistitems[api0]` (jAPI) still passes. (The pre-existing `[api2]`/music-backend failures on `develop` are unrelated to this change.)