### PR TITLE
fix: restore Mopidy 4 cache metadata serialization

### DIFF
--- a/mopidy_youtube/youtube.py
+++ b/mopidy_youtube/youtube.py
@@ -733,13 +733,16 @@ class Video(Entry):
                         with open(
                             os.path.join(cache_location, f"{self.id}.json"), "w"
                         ) as outfile:
-                            json.dump(
-                                convert_video_to_track(
-                                    self, bitrate=int(info.get("tbr", 0))
-                                ),
-                                cls=ModelJSONEncoder,
-                                fp=outfile,
-                            )
+                            if ModelJSONEncoder:
+                                # Mopidy < 4.0
+                                json.dump(track, cls=ModelJSONEncoder, fp=outfile)
+                            else:
+                                # Mopidy >= 4.0
+                                outfile.write(
+                                    track.model_dump_json(
+                                        by_alias=True, exclude_none=True
+                                    )
+                                )
                 else:
                     with youtube_dl.YoutubeDL(ytdl_options) as ydl:
                         info = ydl.extract_info(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -26,7 +26,7 @@ def test_get_config_schema():
     assert "api_enabled" in schema
     assert "channel_id" in schema
     assert "musicapi_enabled" in schema
-    assert "musicapi_cookie" in schema
+    assert "musicapi_cookiefile" in schema
     assert "autoplay_enabled" in schema
     assert "strict_autoplay" in schema
     assert "max_autoplay_length" in schema

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from mopidy_youtube import youtube
@@ -84,20 +86,20 @@ def test_audio_url(api, config, headers, youtube_dl_mock_with_video):
 
 @pytest.mark.parametrize("api", apis)
 def test_audio_url_with_cache_metadata(
-    api, config, headers, youtube_dl_mock_with_video, tmp_path
+    api, config, headers, youtube_dl_mock_with_video, tmp_path, monkeypatch
 ):
     setup_entry_api(api, config, headers)
     youtube.Video.proxy = None
-    youtube.cache_location = str(tmp_path)
+    monkeypatch.setattr(youtube, "cache_location", str(tmp_path))
     video = youtube.Video.get("e1YqueG2gtQ")
 
     (tmp_path / f"{video.id}.webm").write_bytes(b"cached audio")
     (tmp_path / f"{video.id}.webp").write_bytes(b"cached image")
 
     assert video.audio_url.get()
-    assert (tmp_path / f"{video.id}.json").exists()
-
-    youtube.cache_location = None
+    with (tmp_path / f"{video.id}.json").open() as metadata_file:
+        metadata = json.load(metadata_file)
+    assert metadata["uri"] == f"youtube:video:{video.id}"
 
 
 @pytest.mark.parametrize("api", apis)


### PR DESCRIPTION
## Summary

- restore Mopidy-version-specific cache metadata serialization
- validate the cached JSON payload in the existing regression test
- update the stale `musicapi_cookiefile` schema assertion

## Context

#262 added Mopidy 4 cache serialization through Pydantic and was merged as `5f1b074`. A later branch merge (`029a05b`) overwrote that code while retaining the test and changelog entry. With Mopidy 4, `ModelJSONEncoder` is unavailable and `json.dump()` cannot serialize a Pydantic `Track`, so enabling the cache prevents audio URL resolution.

This restores the accepted Mopidy 3/4 branches and strengthens the test to load the generated JSON and verify its track URI. The schema test now checks `musicapi_cookiefile`, which is the key exposed by `Extension.get_config_schema()` and documented in the README.

## Verification

The targeted schema and cache tests pass against both:

- Mopidy 3.4.2: 4 passed
- Mopidy 4.0.1: 4 passed

`black --check` passes for all changed files. The change introduces no new `flake8` findings and removes the existing unused `track` assignment warning from the affected block.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)
